### PR TITLE
Update xlsm_wrapper.py

### DIFF
--- a/xlsm_wrapper.py
+++ b/xlsm_wrapper.py
@@ -18,7 +18,7 @@ class XLSMWrapper(excel_wrapper.ExcelWrapper):
         self._macrosheets = None
         self.xl_international_flags = {XlApplicationInternational.xlLeftBracket: '[',
                                        XlApplicationInternational.xlListSeparator: ',',
-                                       XlApplicationInternational.xlListSeparator: ']'}
+                                       XlApplicationInternational.xlRightBracket: ']'}
 
     def get_xl_international_char(self, flag_name):
         result = None


### PR DESCRIPTION
Fix copy paste error in bracket definition.

This happens because deobfuscator calls get_xl_international_char with XlApplicationInternational.xlRightBracket which is not defined and hence None is returned. It is a copy paste error at root cause.

file 1ee9a96b6222caebab404023dabf34309362fa2ef54b1209f75086fd12911a23

Traceback (most recent call last):
  File "deobfuscator.py", line 542, in <module>
    interpreter = XLMInterpreter(excel_doc)
  File "deobfuscator.py", line 30, in __init__
    self.xlm_parser = self.get_parser()
  File "deobfuscator.py", line 63, in get_parser
    XlApplicationInternational.xlRightBracket))
TypeError: replace() argument 2 must be str, not None