### PR TITLE
Update xlsm_wrapper.py

### DIFF
--- a/XLMMacroDeobfuscator/xlsm_wrapper.py
+++ b/XLMMacroDeobfuscator/xlsm_wrapper.py
@@ -224,6 +224,8 @@ class XLSMWrapper(ExcelWrapper):
         return result
 
     def load_cells(self, macrosheet, macrosheet_obj):
+        if not hasattr(macrosheet_obj.xm_macrosheet.sheetData, 'row'):
+            return
         for row in macrosheet_obj.xm_macrosheet.sheetData.row:
             row_attribs = {}
             for attr in row._attributes:


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "/opt/CAPEv2/utils/../lib/cuckoo/core/plugins.py", line 321, in process
    data = current.run()
  File "/opt/CAPEv2/utils/../modules/processing/static.py", line 2144, in run
    static = Office(self.file_path, self.results).run()
  File "/opt/CAPEv2/utils/../modules/processing/static.py", line 1485, in run
    results = self._parse(self.file_path)
  File "/opt/CAPEv2/utils/../modules/processing/static.py", line 1474, in _parse
    deofuscated_xlm = XLMMacroDeobf(**xlm_kwargs)
  File "/usr/local/lib/python3.6/dist-packages/XLMMacroDeobfuscator/deobfuscator.py", line 981, in process_file
    for step in interpreter.deobfuscate_macro(not kwargs.get("noninteractive")):
  File "/usr/local/lib/python3.6/dist-packages/XLMMacroDeobfuscator/deobfuscator.py", line 777, in deobfuscate_macro
    macros = self.xlm_wrapper.get_macrosheets()
  File "/usr/local/lib/python3.6/dist-packages/XLMMacroDeobfuscator/xlsm_wrapper.py", line 280, in get_macrosheets
    self.load_cells(macrosheet['sheet'], macrosheet['sheet_xml'])
  File "/usr/local/lib/python3.6/dist-packages/XLMMacroDeobfuscator/xlsm_wrapper.py", line 227, in load_cells
    for row in macrosheet_obj.xm_macrosheet.sheetData.row:
  File "/usr/local/lib/python3.6/dist-packages/untangle.py", line 83, in __getattr__
    "'%s' has no attribute '%s'" % (self._name, key)
AttributeError: 'sheetData' has no attribute 'row'
```