### PR TITLE
Update deobfuscator.py

### DIFF
--- a/XLMMacroDeobfuscator/deobfuscator.py
+++ b/XLMMacroDeobfuscator/deobfuscator.py
@@ -1120,6 +1120,7 @@ class XLMInterpreter:
 
     def next_handler(self, arguments, current_cell, interactive, parse_tree_root):
         status = EvalStatus.FullEvaluation
+        next_cell = None
         if self.next_count == 0:
             self.ignore_processing = False
             next_cell = None


### PR DESCRIPTION
fix unassigned use of next_cell
repro file: 8a868633be770dc26525884288c34ba0621170af62f0e18c19b25a17db36726a

[Loading Cells]
--with-ms-excel switch is now deprecated (by default, MS-Excel is not used)
If you want to use MS-Excel, use --with-ms-excel
auto_open: auto_open->K9YZ!$E$829
[Starting Deobfuscation]
CELL:E829      , FullBranching       , IF(OR(AND(AND(OR(MAX(APP.MAXIMIZE(),FALSE),MAX(GET.WORKSPACE(13.0),-1.0)>770.0,MIN(GET.WORKSPACE(14.0),10000.0)>390.0,OR(GET.WORKSPACE(31.0)=FALSE),AND(GET.WORKSPACE(19.0),TRUE))))),MIN(50.0),HALT())
CELL:E829      , PartialEvaluation   , [TRUE] MIN(50)
CELL:E830      , FullEvaluation      ,  SET.NAME(ndrlm,$E$812)
CELL:E831      , FullEvaluation      ,  SET.NAME(aclhzdly,$I$2023:$I$2043)
CELL:E832      , FullEvaluation      ,  SET.NAME(sghdee,$T$4063:$T$4072)
CELL:E833      , FullEvaluation      ,  SET.NAME(czenbevaq,836)
CELL:E834      , FullEvaluation      ,  SET.NAME(garwogus,5)
CELL:E835      , FullEvaluation      ,  NdRLM()
CELL:E812      , PartialEvaluation   ,  SET.NAME("EIZNh",MAX(0.0,-1.0))
CELL:E813      , PartialEvaluation   ,  SET.NAME("dOzPccZhvxtk",MIN(0.0,1.0))
CELL:E814      , PartialEvaluation   ,  WHILE(AND(EIZNh<ROWS(aClHzdLY)))
Traceback (most recent call last):
  File "c:\anaconda3\lib\runpy.py", line 194, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "c:\anaconda3\lib\runpy.py", line 87, in _run_code
    exec(code, run_globals)
  File "c:\Anaconda3\Scripts\xlmdeobfuscator.exe\__main__.py", line 7, in <module>
  File "c:\anaconda3\lib\site-packages\XLMMacroDeobfuscator\deobfuscator.py", line 2143, in main
    process_file(**vars(args))
  File "c:\anaconda3\lib\site-packages\XLMMacroDeobfuscator\deobfuscator.py", line 2021, in process_file
    for step in interpreter.deobfuscate_macro(interactive, start_point):
  File "c:\anaconda3\lib\site-packages\XLMMacroDeobfuscator\deobfuscator.py", line 1610, in deobfuscate_macro
    evaluation_result = self.evaluate_parse_tree(current_cell, parse_tree, interactive)
  File "c:\anaconda3\lib\site-packages\XLMMacroDeobfuscator\deobfuscator.py", line 1445, in evaluate_parse_tree
    child_eval_result = self.evaluate_parse_tree(current_cell, child_node, interactive)
  File "c:\anaconda3\lib\site-packages\XLMMacroDeobfuscator\deobfuscator.py", line 1361, in evaluate_parse_tree
    result = self.evaluate_function(current_cell, parse_tree_root, interactive)
  File "c:\anaconda3\lib\site-packages\XLMMacroDeobfuscator\deobfuscator.py", line 583, in evaluate_function
    eval_result = self._handlers[function_name](arguments, current_cell, interactive, parse_tree_root)
  File "c:\anaconda3\lib\site-packages\XLMMacroDeobfuscator\deobfuscator.py", line 1135, in next_handler
    if next_cell is None:
UnboundLocalError: local variable 'next_cell' referenced before assignment