### PR TITLE
Fixed bug in unwraping of string

### DIFF
--- a/XLMMacroDeobfuscator/deobfuscator.py
+++ b/XLMMacroDeobfuscator/deobfuscator.py
@@ -97,6 +97,11 @@ class EvalResult:
     @staticmethod
     def unwrap_str_literal(string):
         result = str(string)
+
+        if result.count('"') % 2 == 1 :
+            # if we have an uneven count of quotes, we should not unwrap (think of a string like ","JJCCBB")
+            return result
+
         if len(result) > 1 and result.startswith('"') and result.endswith('"'):
             result = result[1:-1].replace('""', '"')
         return result


### PR DESCRIPTION
For an example of the previous bad behavior, see sample [7a99e0ff0d7f0951c53a21dfabc03fb9e06d1c585de62cc71d962c1c4dde4190](https://www.virustotal.com/gui/file/7a99e0ff0d7f0951c53a21dfabc03fb9e06d1c585de62cc71d962c1c4dde4190)

The bug pertains to the unwrapping of strings. A string that should not
have been unwrapped was stripped of it's quotes, leading to this
situation :

Correct evaluation :
`=IF(MFCO5<0, CALL("urlmon","URLDownloadToFileA","JJCCBB",0, (...)`

Evaluation prior to fix :
`=IF(MFCO5<0, CALL("urlmon","URLDownloadToFileA,"JJCCBB,0,"  (...)`

because the string `","JJCCBB"` was being stripped to `"JJCCBB`

This caused an error in the parsing of the formula, crashing the
program.

To fix it, I have changed the unwrapping function to avoid unwrapping
when the count of quotes is uneven