### PR TITLE
fix missing wrapping in t_handler()

### DIFF
--- a/XLMMacroDeobfuscator/deobfuscator.py
+++ b/XLMMacroDeobfuscator/deobfuscator.py
@@ -1454,7 +1454,7 @@ class XLMInterpreter:
             status = EvalStatus.FullEvaluation
         else:
             status = EvalStatus.PartialEvaluation
-        return EvalResult(arg_eval_result.next_cell, status, return_val, str(return_val))
+        return EvalResult(arg_eval_result.next_cell, status, return_val, EvalResult.wrap_str_literal(str(return_val), must_wrap=True))
 
     def int_handler(self, arguments, current_cell, interactive, parse_tree_root):
         arg_eval_result = self.evaluate_parse_tree(current_cell, arguments[0], interactive)


### PR DESCRIPTION
This is a proposition to fix #108.
The fix proposed in #109 corrects the issue in most cases without properly identifying the cause, which might cause other issues.

### The issue
When we deal with concatenation expressions in `evaluate_parse_tree()`, the retrieved value is always unwrapped (for example at lines 2274 and 2276).

However in `t_handler()`, the returned `EvalResult` does not wrap the value.

This is ok when the value does not start and end with quotes (this is the majority of cases), since `unwrap_str_literal()` does nothing if the string to unwrap does not start and end with quotes.

But if the result of `t_handler()` starts and ends with quotes, they are removed in `evaluate_parse_tree()`, and we get a wrong value to evaluate the rest of the formula, with missing quotes.

As a reference, here is the definition of the `T()` excel function:
*The Excel T function returns text when given a text value and an empty string ("") for numbers, dates, and the logical values TRUE and FALSE. You can use the T function to remove values that are not text.*

### The fix
The fix I'm proposing consists in always wrapping the result of `t_handler()` since it is text by definition. That way we do not loose quotes when unwrapping.
