### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 pyxlsb2
-lark-parser
+lark<1.0.0
 xlrd2
-untangle==1.2.1
+untangle>=1.2.1
 msoffcrypto-tool
 defusedxml
 roman


### PR DESCRIPTION
change cardinality of dependencies
lark-parser package is no longer getting updates, the development moved to lark package.  Problem is that in version 1.0.0 the lark API has changed in a way which is not working for the deobfuscator - please consider update.

related to issue #118 